### PR TITLE
Include user metadata in `ObjectMetadata` as a `Map[String, String]`

### DIFF
--- a/src/main/scala/s3dsl/S3Dsl.scala
+++ b/src/main/scala/s3dsl/S3Dsl.scala
@@ -14,7 +14,6 @@ import mouse.all._
 import cats.effect.{ConcurrentEffect, ContextShift, Sync}
 import s3dsl.domain.auth.Domain.{PolicyRead, PolicyWrite}
 
-
 trait S3Dsl[F[_]] {
 
   def createBucket(bucket: BucketName): F[Unit]
@@ -242,7 +241,8 @@ object S3Dsl {
     val etag = Option(aws.getETag).map(ETag.apply)
     val expiration = Option(aws.getExpirationTime).map(ExpirationTime.apply)
     val lastModified = Option(aws.getLastModified).map(LastModified.apply)
-    ObjectMetadata(contentType, aws.getContentLength, md5, etag, expiration, lastModified)
+    val userMetadata = Option(aws.getUserMetadata.asScala.toMap).getOrElse(Map.empty[String, String])
+    ObjectMetadata(contentType, aws.getContentLength, md5, etag, expiration, lastModified, userMetadata)
   }
 
   private def createAwsS3Client(config: S3Config): AmazonS3 = {

--- a/src/main/scala/s3dsl/domain/S3.scala
+++ b/src/main/scala/s3dsl/domain/S3.scala
@@ -34,7 +34,6 @@ object S3 {
     override def toString: String = s"${bucket.value}/${key.value}"
   }
 
-
   //
   // Object & Object metadata
   //
@@ -53,14 +52,14 @@ object S3 {
                                   md5: Option[MD5],
                                   etag: Option[ETag],
                                   expirationTime: Option[ExpirationTime],
-                                  lastModified: Option[LastModified])
+                                  lastModified: Option[LastModified],
+                                  userMedata: Map[String, String])
 
   final case class ObjectSummary(path: Path,
                                  size: Long,
                                  etag: Option[ETag],
                                  storageClass: Option[StorageClass],
                                  lastModified: Option[LastModified])
-
 
   //
   // Access control
@@ -114,7 +113,6 @@ object S3 {
   final case class Grant(grantee: Grantee, permission: Permission)
 
   final case class AccessControlList(grants: List[Grant], owner: Owner)
-
 
   //
   // HTTP Method


### PR DESCRIPTION
When mapping from the AWS SDK `ObjectMetadata` to the domain `ObjectMetadata` this change now extracts the user metadata as a `Map[String, String]` and includes it in the resulting object.